### PR TITLE
fix bug in argument in call to request-redirect!

### DIFF
--- a/src/crisco/web.clj
+++ b/src/crisco/web.clj
@@ -19,7 +19,7 @@
                   )})
   (GET "/:slug" [slug]
        {:status 301
-        :headers {"Location" (data/request-redirect! [slug])}})
+        :headers {"Location" (data/request-redirect! slug)}})
   (POST "/shorten/:slug" [slug target]
         (if (data/store-slug! slug target)
           {:status 200}


### PR DESCRIPTION
In this call to `request-redirect!`, the argument is incorrectly wrapped in a vector.

As a result, all calls to the GET /slug path will fail to return the looked-up value.

This is also a bug in the code snippets shown in: http://ben.vandgrift.com/2014/04/24/a-clojure-datomic-web-app-tutorial.html
